### PR TITLE
#1186 Added support for AWS Session Tokens

### DIFF
--- a/ecs/backend.go
+++ b/ecs/backend.go
@@ -47,6 +47,7 @@ type ContextParams struct {
 	SecretKey    string
 	Profile      string
 	Region       string
+	SessionToken string
 	CredsFromEnv bool
 }
 

--- a/ecs/context_test.go
+++ b/ecs/context_test.go
@@ -56,10 +56,11 @@ func TestCreateContextDataByKeys(t *testing.T) {
 	}
 
 	data, _, err := c.createContextData(context.TODO(), ContextParams{
-		Name:      "test",
-		AccessKey: "ABCD",
-		SecretKey: "X&123",
-		Region:    "eu-west-3",
+		Name:         "test",
+		AccessKey:    "ABCD",
+		SecretKey:    "X&123",
+		SessionToken: "X&123",
+		Region:       "eu-west-3",
 	})
 	assert.NilError(t, err)
 	assert.Equal(t, data.(store.EcsContext).Profile, "default")
@@ -134,6 +135,7 @@ func TestCreateContextDataByKeysInteractive(t *testing.T) {
 	ui.EXPECT().Select("Create a Docker context using:", gomock.Any()).Return(0, nil)
 	ui.EXPECT().Input("AWS Access Key ID", gomock.Any()).Return("ABCD", nil)
 	ui.EXPECT().Password("Enter AWS Secret Access Key").Return("X&123", nil)
+	ui.EXPECT().Password("AWS Session Token (optional)").Return("X&123", nil)
 	ui.EXPECT().Select("Region", []string{"us-east-1", "eu-west-3"}).Return(1, nil)
 
 	data, _, err := c.createContextData(context.TODO(), ContextParams{})

--- a/ecs/testdata/context-by-keys-credentials.golden
+++ b/ecs/testdata/context-by-keys-credentials.golden
@@ -1,3 +1,4 @@
 [default]
 aws_access_key_id     = ABCD
 aws_secret_access_key = X&123
+aws_session_token     = X&123


### PR DESCRIPTION
**What I did**
Added support for AWS Session Tokens to allow use of SSO roles in MFA environments 
**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
#1186
<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
